### PR TITLE
Comando Erróneo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ using Docker.
 # How to run this project
 - Install Docker and Docker Compose
 - Execute `docker-compose up -d`: This command starts a local server with the API running over 8000 port.
-- Get inside the docker container executing `docker exec -it postman-course_web_1 bash`
+- Get inside the docker container executing `docker exec -it postmancourse_web_1 bash`
 - Inside the docker container execute `source admin_info.sh`
 - Run the migrations `python manage.py runscript migrations.admin_migration`


### PR DESCRIPTION
El comando "docker exec -it postman-course_web_1 bash" no funciona, por el guión que está al medio, siendo esta la forma en la que funciona correctamente "docker exec -it postmancourse_web_1 bash"